### PR TITLE
feat(node): external sourcemap

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,8 +35,16 @@ pub struct Vlq {
 }
 
 impl SourceMap {
+  /// Create a new Speedy SourceMap instance
+  pub fn new(source_root: &str) -> Self {
+    Self {
+      inner: PSourceMap::new(source_root),
+      vlq: None,
+    }
+  }
+
   /// Create a new Speedy SourceMap instance directly from Parcel SourceMap
-  pub fn new(parcel_sourcemap: PSourceMap) -> Self {
+  pub fn new_from_parcel_sourcemap(parcel_sourcemap: PSourceMap) -> Self {
     Self {
       inner: parcel_sourcemap,
       vlq: None,
@@ -73,7 +81,9 @@ impl SourceMap {
       .collect::<Result<Vec<_>>>()?;
 
     if len == 1 {
-      return Ok(SourceMap::new(parcel_sm[0].take().unwrap()));
+      return Ok(Self::new_from_parcel_sourcemap(
+        parcel_sm[0].take().unwrap(),
+      ));
     };
 
     let last = parcel_sm.last_mut().unwrap().take().unwrap();
@@ -90,7 +100,7 @@ impl SourceMap {
       },
     )?;
 
-    Ok(Self::new(parcel_sourcemap))
+    Ok(Self::new_from_parcel_sourcemap(parcel_sourcemap))
   }
 
   pub fn generate_vlq(&mut self) -> Result<&Vlq> {

--- a/node/__tests__/index.spec.ts
+++ b/node/__tests__/index.spec.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { SourceMap } from '..'
 
 describe('merge', () => {
@@ -23,3 +24,29 @@ describe('merge', () => {
     console.log(sourcemap.toMap())
   })
 })
+
+describe('external', () => {
+  it('should create and use external sourcemap', () => {
+    const sourcemap = SourceMap.mergeMaps([
+      {
+        mappings: 'AAAA,aAEA,IAAIA,IAAM,WACR,MAAO',
+        sources: ['0'],
+        sourcesContent: [
+          `use strict";\n\nvar foo = function foo() {\n  return "foo";\n};`,
+        ],
+        names: ['foo'],
+      },
+      {
+        mappings: ';;AAAA,IAAIA,GAAG,GAAG,SAANA,GAAM;AAAA,SAAM,KAAN;AAAA,CAAV',
+        sources: ['unknown'],
+        sourcesContent: [`let foo = () => "foo";`],
+        names: ['foo'],
+      },
+    ])
+    const external = sourcemap.toExternalSourcemap()
+    const sourcemap_external = SourceMap.newFromExternalSourcemap(external)
+
+    assert.equal(sourcemap.toString(), sourcemap_external.toString())
+  })
+})
+

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -18,7 +18,13 @@ export interface VlqMap {
   columnOffset?: number | undefined | null
 }
 export class SourceMap {
+  /** Create Speedy SourceMap from external Sourcemap instance. It's useful when storing cache on Node.js side */
+  static newFromExternalSourcemap(
+    external: ExternalObject<SpeedySourceMap>,
+  ): SourceMap
   static mergeMaps(vlqMaps: Array<String | VlqMap>): SourceMap
+  /** Convert Speedy SourceMap to External Value which can be stored in Node.js side indefinitely and useful when making mapChains or any caches */
+  toExternalSourcemap(): ExternalObject<SpeedySourceMap>
   toComment(): string
   toString(): string
   toMap(): {


### PR DESCRIPTION
Add napi external to store SourceMap instance on Node.js side, which is useful for map chaining.

Example:
```typescript
// create external sourcemap and store it on the Node.js side
let map1 = SourceMap.mergeMaps(...).toExternalSourcemap()
let map2 = SourceMap.mergeMaps(...).toExternalSourcemap()

// maybe there's other computations

// then we consume these maps
let merged = SourceMap.mergeMaps(
  SourceMap.newFromExternalSourcemap(map2), 
  SourceMap.newFromExternalSourcemap(map1)
)

merged.toString()
```
